### PR TITLE
Error reporting

### DIFF
--- a/lib/share_progress/client.rb
+++ b/lib/share_progress/client.rb
@@ -20,13 +20,20 @@ module ShareProgress
       private
 
       def format_response(http_response)
-        if http_response.code != 200 && http_response.code != 404
-          raise ApiError.new("Status #{http_response.code}: #{http_response['message']}")
-        end
+        check_api_error(http_response)
         formatted = http_response['response'].nil? ? [] : http_response['response']
         errors = http_response['success'] ? {} : http_response['message']
         formatted.each { |r| r['errors'] = errors }
         formatted
+      end
+
+      def check_api_error(http_response)
+        return if http_response.code < 300
+        return if http_response.code == 404 || http_response.code == 422
+        error_msg = "Status #{http_response.code}: #{http_response['message']}\n" +
+                    "Requesting: #{http_response.request.uri.to_s}\n" +
+                    "With Body: #{http_response.request.raw_body}"
+        raise ApiError.new(error_msg)
       end
 
     end

--- a/lib/share_progress/client.rb
+++ b/lib/share_progress/client.rb
@@ -20,6 +20,9 @@ module ShareProgress
       private
 
       def format_response(http_response)
+        if http_response.code != 200 && http_response.code != 404
+          raise ApiError.new("Status #{http_response.code}: #{http_response['message']}")
+        end
         formatted = http_response['response'].nil? ? [] : http_response['response']
         errors = http_response['success'] ? {} : http_response['message']
         formatted.each { |r| r['errors'] = errors }

--- a/lib/share_progress/errors.rb
+++ b/lib/share_progress/errors.rb
@@ -1,6 +1,7 @@
 module ShareProgress
   class ShareProgressError < StandardError; end
   class RecordNotFound < ShareProgressError; end
+  class ApiError < ShareProgressError; end
   class AnalyticsNotFound < ShareProgressError; end
   class CouldNotParseVariant < ShareProgressError; end
 end

--- a/share_progress.gemspec
+++ b/share_progress.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr'
 
   # Runtime Dependencies
-  spec.add_runtime_dependency 'httparty'
+  spec.add_runtime_dependency 'httparty', '>= 0.13'
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -7,10 +7,11 @@ describe ShareProgress::Client do
 
   describe "post", :vcr do
 
-    let(:args) { ["/buttons/update", {body: {page_url:"http//act.sumofus.org/sign/What_Fast_Track_Means_infographic/", button_template:"sp_fb_large"}}] }
+    let(:args) { ["/buttons/update", {body: {page_url:"http://act.sumofus.org/sign/What_Fast_Track_Means_infographic/", button_template:"sp_fb_large"}}] }
+    let(:response) { [{"id"=>15887, "page_url"=>"http://act.sumofus.org/sign/What_Fast_Track_Means_infographic/", "page_title"=>"What Fast Track Means | SumOfUs.org", "button_template"=>"sp_fb_large", "share_button_html"=>"<div class='sp_15887 sp_fb_large' ></div>", "found_snippet"=>true, "is_active"=>false, "variants"=>{"facebook"=>[], "email"=>[], "twitter"=>[]}, "advanced_options"=>{"automatic_traffic_routing"=>"true", "buttons_optimize_actions"=>nil, "customize_params"=>nil, "id_pass"=>{"id"=>"id", "passed"=>"referrer_id"}}, "errors"=>{}}] }
 
     it 'returns a formatted response with good args' do
-      expect(ShareProgress::Client.post(*args)).to eq []
+      expect(ShareProgress::Client.post(*args)).to eq response
     end
 
     it "raises an error when there's a 500 response" do
@@ -19,7 +20,23 @@ describe ShareProgress::Client do
       expect{ ShareProgress::Client.post(*args) }.to raise_error(ShareProgress::ApiError, "Status 500: Bad API Key")
       ShareProgress::Client::default_params[:key] = key
     end
+  end
 
+  describe "get", :vcr do
+
+    let(:args) { ["/buttons/read", { query: { id: 15887 } } ] }
+    let(:response) { [{"id"=>15887, "page_url"=>"http://act.sumofus.org/sign/What_Fast_Track_Means_infographic/", "page_title"=>"What Fast Track Means | SumOfUs.org", "button_template"=>"sp_fb_large", "share_button_html"=>"<div class='sp_15887 sp_fb_large' ></div>", "found_snippet"=>true, "is_active"=>false, "variants"=>{"facebook"=>[{"id"=>65846, "facebook_title"=>nil, "facebook_description"=>nil, "facebook_thumbnail"=>nil}], "email"=>[{"id"=>65845, "email_subject"=>nil, "email_body"=>nil}], "twitter"=>[{"id"=>65847, "twitter_message"=>nil}]}, "advanced_options"=>{"automatic_traffic_routing"=>"true", "buttons_optimize_actions"=>nil, "customize_params"=>nil, "id_pass"=>{"id"=>"id", "passed"=>"referrer_id"}}, "errors"=>{}}] }
+
+    it 'returns a formatted response with good args' do
+      expect(ShareProgress::Client.get(*args)).to eq response
+    end
+
+    it "raises an error when there's a 500 response" do
+      key = ShareProgress::Client::default_params[:key]
+      ShareProgress::Client::default_params[:key] = 'wrong'
+      expect{ ShareProgress::Client.get(*args) }.to raise_error(ShareProgress::ApiError, "Status 500: Bad API Key")
+      ShareProgress::Client::default_params[:key] = key
+    end
   end
 
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'webmock/rspec'
+require 'share_progress'
+require 'httparty'
+
+describe ShareProgress::Client do
+
+  describe "post", :vcr do
+
+    let(:args) { ["/buttons/update", {body: {page_url:"http//act.sumofus.org/sign/What_Fast_Track_Means_infographic/", button_template:"sp_fb_large"}}] }
+
+    it 'returns a formatted response with good args' do
+      expect(ShareProgress::Client.post(*args)).to eq []
+    end
+
+    it "raises an error when there's a 500 response" do
+      key = ShareProgress::Client::default_params[:key]
+      ShareProgress::Client::default_params[:key] = 'wrong'
+      expect{ ShareProgress::Client.post(*args) }.to raise_error(ShareProgress::ApiError, "Status 500: Bad API Key")
+      ShareProgress::Client::default_params[:key] = key
+    end
+
+  end
+
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -5,20 +5,28 @@ require 'httparty'
 
 describe ShareProgress::Client do
 
+  before :each do
+    @key = ShareProgress::Client::default_params[:key]
+  end
+
+  after :each do
+    ShareProgress::Client::default_params[:key] = @key
+  end
+
   describe "post", :vcr do
 
     let(:args) { ["/buttons/update", {body: {page_url:"http://act.sumofus.org/sign/What_Fast_Track_Means_infographic/", button_template:"sp_fb_large"}}] }
     let(:response) { [{"id"=>15887, "page_url"=>"http://act.sumofus.org/sign/What_Fast_Track_Means_infographic/", "page_title"=>"What Fast Track Means | SumOfUs.org", "button_template"=>"sp_fb_large", "share_button_html"=>"<div class='sp_15887 sp_fb_large' ></div>", "found_snippet"=>true, "is_active"=>false, "variants"=>{"facebook"=>[], "email"=>[], "twitter"=>[]}, "advanced_options"=>{"automatic_traffic_routing"=>"true", "buttons_optimize_actions"=>nil, "customize_params"=>nil, "id_pass"=>{"id"=>"id", "passed"=>"referrer_id"}}, "errors"=>{}}] }
+    let(:error) { "Status 500: Bad API Key\nRequesting: http://run.shareprogress.org/api/v1/buttons/update?key=wrong\nWith Body: page_url=http%3A%2F%2Fact.sumofus.org%2Fsign%2FWhat_Fast_Track_Means_infographic%2F&button_template=sp_fb_large" }
+
 
     it 'returns a formatted response with good args' do
       expect(ShareProgress::Client.post(*args)).to eq response
     end
 
     it "raises an error when there's a 500 response" do
-      key = ShareProgress::Client::default_params[:key]
       ShareProgress::Client::default_params[:key] = 'wrong'
-      expect{ ShareProgress::Client.post(*args) }.to raise_error(ShareProgress::ApiError, "Status 500: Bad API Key")
-      ShareProgress::Client::default_params[:key] = key
+      expect{ ShareProgress::Client.post(*args) }.to raise_error(ShareProgress::ApiError, error)
     end
   end
 
@@ -26,16 +34,16 @@ describe ShareProgress::Client do
 
     let(:args) { ["/buttons/read", { query: { id: 15887 } } ] }
     let(:response) { [{"id"=>15887, "page_url"=>"http://act.sumofus.org/sign/What_Fast_Track_Means_infographic/", "page_title"=>"What Fast Track Means | SumOfUs.org", "button_template"=>"sp_fb_large", "share_button_html"=>"<div class='sp_15887 sp_fb_large' ></div>", "found_snippet"=>true, "is_active"=>false, "variants"=>{"facebook"=>[{"id"=>65846, "facebook_title"=>nil, "facebook_description"=>nil, "facebook_thumbnail"=>nil}], "email"=>[{"id"=>65845, "email_subject"=>nil, "email_body"=>nil}], "twitter"=>[{"id"=>65847, "twitter_message"=>nil}]}, "advanced_options"=>{"automatic_traffic_routing"=>"true", "buttons_optimize_actions"=>nil, "customize_params"=>nil, "id_pass"=>{"id"=>"id", "passed"=>"referrer_id"}}, "errors"=>{}}] }
+    let(:error) { "Status 500: Bad API Key\nRequesting: http://run.shareprogress.org/api/v1/buttons/read?key=wrong&id=15887\nWith Body: "}
+
 
     it 'returns a formatted response with good args' do
       expect(ShareProgress::Client.get(*args)).to eq response
     end
 
     it "raises an error when there's a 500 response" do
-      key = ShareProgress::Client::default_params[:key]
       ShareProgress::Client::default_params[:key] = 'wrong'
-      expect{ ShareProgress::Client.get(*args) }.to raise_error(ShareProgress::ApiError, "Status 500: Bad API Key")
-      ShareProgress::Client::default_params[:key] = key
+      expect{ ShareProgress::Client.get(*args) }.to raise_error(ShareProgress::ApiError, error)
     end
   end
 

--- a/spec/vcr/cassettes/ShareProgress_Client/get/raises_an_error_when_there_s_a_500_response.yml
+++ b/spec/vcr/cassettes/ShareProgress_Client/get/raises_an_error_when_there_s_a_500_response.yml
@@ -1,11 +1,11 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: http://run.shareprogress.org/api/v1/buttons/update?key=wrong
+    method: get
+    uri: http://run.shareprogress.org/api/v1/buttons/read?id=15887&key=wrong
     body:
-      encoding: UTF-8
-      string: page_url=http%3A%2F%2Fact.sumofus.org%2Fsign%2FWhat_Fast_Track_Means_infographic%2F&button_template=sp_fb_large
+      encoding: US-ASCII
+      string: ''
     headers: {}
   response:
     status:
@@ -17,7 +17,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Thu, 17 Sep 2015 00:40:02 GMT
+      - Thu, 17 Sep 2015 00:45:20 GMT
       Status:
       - 500 Internal Server Error
       X-Frame-Options:
@@ -33,14 +33,14 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - ae6712d2-7b5a-4abe-8a3c-58168052615d
+      - e759d744-f0f2-4ae2-b18b-47d6ce9cdaa6
       X-Runtime:
-      - '0.008140'
+      - '0.005747'
       Via:
       - 1.1 vegur
     body:
       encoding: UTF-8
       string: '{"success":false,"message":"Bad API Key","response":[]}'
     http_version: 
-  recorded_at: Thu, 17 Sep 2015 00:41:26 GMT
+  recorded_at: Thu, 17 Sep 2015 00:46:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr/cassettes/ShareProgress_Client/get/returns_a_formatted_response_with_good_args.yml
+++ b/spec/vcr/cassettes/ShareProgress_Client/get/returns_a_formatted_response_with_good_args.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://run.shareprogress.org/api/v1/buttons/read?id=15887&key=<API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - close
+      Date:
+      - Thu, 17 Sep 2015 00:45:19 GMT
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - chrome=1
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '29'
+      X-Ratelimit-Reset:
+      - '1442450779'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - '"515217e7a8fd3f350985bbc7eb8959dd"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ea91a75c-3c9b-43f5-b05d-fd05185b58af
+      X-Runtime:
+      - '0.565298'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"response":[{"id":15887,"page_url":"http://act.sumofus.org/sign/What_Fast_Track_Means_infographic/","page_title":"What
+        Fast Track Means | SumOfUs.org","button_template":"sp_fb_large","share_button_html":"\u003Cdiv
+        class=''sp_15887 sp_fb_large'' \u003E\u003C/div\u003E","found_snippet":true,"is_active":false,"variants":{"facebook":[{"id":65846,"facebook_title":null,"facebook_description":null,"facebook_thumbnail":null}],"email":[{"id":65845,"email_subject":null,"email_body":null}],"twitter":[{"id":65847,"twitter_message":null}]},"advanced_options":{"automatic_traffic_routing":"true","buttons_optimize_actions":null,"customize_params":null,"id_pass":{"id":"id","passed":"referrer_id"}}}],"message":null}'
+    http_version: 
+  recorded_at: Thu, 17 Sep 2015 00:46:43 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr/cassettes/ShareProgress_Client/post/raises_an_error_when_there_s_a_500_response.yml
+++ b/spec/vcr/cassettes/ShareProgress_Client/post/raises_an_error_when_there_s_a_500_response.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://run.shareprogress.org/api/v1/buttons/update?key=wrong
+    body:
+      encoding: UTF-8
+      string: page_url=http%2F%2Fact.sumofus.org%2Fsign%2FWhat_Fast_Track_Means_infographic%2F&button_template=sp_fb_large
+    headers: {}
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - close
+      Date:
+      - Wed, 16 Sep 2015 18:14:27 GMT
+      Status:
+      - 500 Internal Server Error
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - chrome=1
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 80300b3a-3006-44d9-beb7-a563b687c27f
+      X-Runtime:
+      - '0.006357'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"success":false,"message":"Bad API Key","response":[]}'
+    http_version: 
+  recorded_at: Wed, 16 Sep 2015 18:15:51 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr/cassettes/ShareProgress_Client/post/returns_a_formatted_response_with_good_args.yml
+++ b/spec/vcr/cassettes/ShareProgress_Client/post/returns_a_formatted_response_with_good_args.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://run.shareprogress.org/api/v1/buttons/update?key=<API_KEY>
+    body:
+      encoding: UTF-8
+      string: page_url=http%3A%2F%2Fact.sumofus.org%2Fsign%2FWhat_Fast_Track_Means_infographic%2F&button_template=sp_fb_large
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - close
+      Date:
+      - Thu, 17 Sep 2015 00:40:02 GMT
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - chrome=1
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '29'
+      X-Ratelimit-Reset:
+      - '1442450460'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - '"5a27c8cbb50921246141b56c2f136a33"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - aa532f0d-59c7-410a-b4fd-f87c061faabd
+      X-Runtime:
+      - '1.098132'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"response":[{"id":15887,"page_url":"http://act.sumofus.org/sign/What_Fast_Track_Means_infographic/","page_title":"What
+        Fast Track Means | SumOfUs.org","button_template":"sp_fb_large","share_button_html":"\u003Cdiv
+        class=''sp_15887 sp_fb_large'' \u003E\u003C/div\u003E","found_snippet":true,"is_active":false,"variants":{"facebook":[],"email":[],"twitter":[]},"advanced_options":{"automatic_traffic_routing":"true","buttons_optimize_actions":null,"customize_params":null,"id_pass":{"id":"id","passed":"referrer_id"}}}],"message":null}'
+    http_version: 
+  recorded_at: Thu, 17 Sep 2015 00:41:26 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
When we got an error from SP, we were previously assuming it was a validation error and trying to parse it as such. This led to some cryptic errors cropping up when we should really have just been throwing an ApiError for the benefit of the stack trace. 

Now when we get something thats not 200, 404, or 422 from SP (those are handled, or 422 would be if they used that instead of 200 for validation errors) we raise ApiError with the status code and the error message. However, because SP tends to just give message-less 500 errors for data errors, it also logs the request URI and body so that we can ask Jim whats up.
